### PR TITLE
Run Prisma generate on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Next.js app that audits WordPress sites and streams progress.
    nvm use
    node --version
    npm install
+   npx prisma generate # initialize Prisma client if needed
    npm run dev
    ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "6.13.0",


### PR DESCRIPTION
## Summary
- Generate Prisma client on install to avoid `@prisma/client did not initialize` errors.
- Document Prisma initialization step in setup instructions.

## Testing
- `npm run postinstall`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973c4ae5a8832e8cf27a544cfd4f25