### PR TITLE
Use SQLite for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://user:password@your-neon-host/neondb?sslmode=require"
+DATABASE_URL="file:./dev.db"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Next.js app that audits WordPress sites and streams progress.
 
-Uses [Prisma](https://www.prisma.io/) with a [Neon](https://neon.tech/) Postgres database.
+Uses [Prisma](https://www.prisma.io/) with a SQLite database file.
 
 ## Setup
 
@@ -11,10 +11,12 @@ Uses [Prisma](https://www.prisma.io/) with a [Neon](https://neon.tech/) Postgres
    nvm use
    node --version
    npm install
-   cp .env.example .env # set DATABASE_URL for Neon
-   npx prisma generate # initialize Prisma client
+   cp .env.example .env # sets DATABASE_URL for SQLite
+   npx prisma db push # create the dev.db SQLite file
    npm run dev
    ```
+
+The development server uses the `dev.db` SQLite file specified in `.env`.
 
 ## Locked Versions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@neondatabase/serverless": "^1.0.1",
-        "@prisma/adapter-neon": "^6.13.0",
         "@prisma/client": "6.13.0",
         "@radix-ui/react-slot": "1.2.3",
         "@react-pdf/renderer": "4.3.0",
@@ -1268,34 +1266,6 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
-    "node_modules/@neondatabase/serverless": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.1.tgz",
-      "integrity": "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.15.30",
-        "@types/pg": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=19.0.0"
-      }
-    },
-    "node_modules/@neondatabase/serverless/node_modules/@types/node": {
-      "version": "22.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
-      "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@neondatabase/serverless/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
     "node_modules/@next/env": {
       "version": "15.4.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.6.tgz",
@@ -1504,17 +1474,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@prisma/adapter-neon": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-6.13.0.tgz",
-      "integrity": "sha512-pJ1f21C/iWpuVhj4R7A6VtkewUJbqwgdzrvFRR9pxSbSSAl+WG3P1HIbR/Ho9uJShjGsJ2Y96FdW83VaGr5O4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@neondatabase/serverless": ">0.6.0 <2",
-        "@prisma/driver-adapter-utils": "6.13.0",
-        "postgres-array": "3.0.4"
-      }
-    },
     "node_modules/@prisma/client": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.13.0.tgz",
@@ -1554,16 +1513,8 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.13.0.tgz",
       "integrity": "sha512-um+9pfKJW0ihmM83id9FXGi5qEbVJ0Vxi1Gm0xpYsjwUBnw6s2LdPBbrsG9QXRX46K4CLWCTNvskXBup4i9hlw==",
+      "devOptional": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@prisma/driver-adapter-utils": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.13.0.tgz",
-      "integrity": "sha512-72gQS/rz0KRV1bvi37OGu5PgMAzTQplFZuTo1kSb4hK7sm0PTvl7+V4NFHdwXEUecTq/+FnF9Ts9Ac+iKPnEow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.13.0"
-      }
     },
     "node_modules/@prisma/engines": {
       "version": "6.13.0",
@@ -2536,6 +2487,7 @@
       "version": "24.2.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
       "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -2547,17 +2499,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/@types/pg": {
-      "version": "8.15.5",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
-      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
     },
     "node_modules/@types/react": {
       "version": "19.1.9",
@@ -7875,46 +7816,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
-      "license": "MIT"
-    },
-    "node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pg-types/node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8022,45 +7923,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
-    },
-    "node_modules/postgres-array": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
-      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9532,6 +9394,7 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-properties": {
@@ -10060,15 +9923,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "postinstall": "prisma generate"
   },
   "dependencies": {
-    "@neondatabase/serverless": "^1.0.1",
-    "@prisma/adapter-neon": "^6.13.0",
     "@prisma/client": "6.13.0",
     "@radix-ui/react-slot": "1.2.3",
     "@react-pdf/renderer": "4.3.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,11 +1,10 @@
 datasource db {
-  provider = "postgresql"
+  provider = "sqlite"
   url      = env("DATABASE_URL")
 }
 
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["driverAdapters"]
+  provider = "prisma-client-js"
 }
 
 model Audit {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,15 +1,10 @@
 import { PrismaClient } from "@prisma/client";
-import { PrismaNeon } from "@prisma/adapter-neon";
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
-
-const connectionString = process.env.DATABASE_URL!;
-const adapter = new PrismaNeon({ connectionString });
 
 export const prisma =
   globalForPrisma.prisma ||
   new PrismaClient({
-    adapter,
     log: ["error"],
   });
 


### PR DESCRIPTION
## Summary
- switch Prisma datasource back to SQLite
- drop Neon adapter and dependencies
- document dev setup using local `dev.db` SQLite file

## Testing
- `npx prisma db push`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68975b76f2c0832eb6de00b2ff456fe7