### PR TITLE
fix: await params in audit route

### DIFF
--- a/src/app/api/audit/[id]/route.ts
+++ b/src/app/api/audit/[id]/route.ts
@@ -2,9 +2,13 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getEmitter } from "@/lib/audit";
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
-  const emitter = getEmitter(params.id);
-  const audit = await prisma.audit.findUnique({ where: { id: params.id } });
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const emitter = getEmitter(id);
+  const audit = await prisma.audit.findUnique({ where: { id } });
   return new Response(
     new ReadableStream({
       start(controller) {


### PR DESCRIPTION
## Summary
- await params before usage to satisfy Next.js dynamic route API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976a9b5e94832ea1dfadc6b3ff0ecb