### PR TITLE
Close audit event stream when finished

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,11 @@ export default function Home() {
     const { auditId } = await res.json();
     const es = new EventSource(`/api/audit/${auditId}`);
     es.onmessage = (ev) => {
-      setMessages((m) => [...m, ev.data]);
+      const data = JSON.parse(ev.data);
+      setMessages((m) => [...m, JSON.stringify(data)]);
+      if (data.status === "done" || data.status === "error") {
+        es.close();
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- close audit EventSource after completion to prevent endless reconnects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977655c45c832eb4a611c908b2240b