### PR TITLE
Fetch all PageSpeed categories

### DIFF
--- a/src/lib/tools.test.ts
+++ b/src/lib/tools.test.ts
@@ -41,7 +41,15 @@ describe("fetchPageSpeedScores", () => {
     };
     nock("https://www.googleapis.com")
       .get("/pagespeedonline/v5/runPagespeed")
-      .query({ url: "https://example.com" })
+      .query({
+        url: "https://example.com",
+        category: [
+          "performance",
+          "accessibility",
+          "best-practices",
+          "seo",
+        ],
+      })
       .reply(200, sample);
     const scores = await fetchPageSpeedScores("https://example.com");
     expect(scores).toEqual({
@@ -66,7 +74,16 @@ describe("fetchPageSpeedScores", () => {
     process.env.PAGESPEED_API_KEY = "test123";
     nock("https://www.googleapis.com")
       .get("/pagespeedonline/v5/runPagespeed")
-      .query({ url: "https://example.com", key: "test123" })
+      .query({
+        url: "https://example.com",
+        category: [
+          "performance",
+          "accessibility",
+          "best-practices",
+          "seo",
+        ],
+        key: "test123",
+      })
       .reply(200, sample);
     const scores = await fetchPageSpeedScores("https://example.com");
     expect(scores).toEqual({

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -38,13 +38,18 @@ export async function fetchPageSpeedScores(siteUrl: string): Promise<PageSpeedSc
     seo: null,
   };
   try {
+    const searchParams = new URLSearchParams([
+      ["url", siteUrl],
+      ["category", "performance"],
+      ["category", "accessibility"],
+      ["category", "best-practices"],
+      ["category", "seo"],
+    ]);
+    if (process.env.PAGESPEED_API_KEY) {
+      searchParams.append("key", process.env.PAGESPEED_API_KEY);
+    }
     const res = await got("https://www.googleapis.com/pagespeedonline/v5/runPagespeed", {
-      searchParams: {
-        url: siteUrl,
-        ...(process.env.PAGESPEED_API_KEY
-          ? { key: process.env.PAGESPEED_API_KEY }
-          : {}),
-      },
+      searchParams,
       timeout: { request: 15000 },
       retry: { limit: 1 },
     }).json<{ lighthouseResult?: { categories?: Record<string, { score?: number }> } }>();


### PR DESCRIPTION
## Summary
- Include performance, accessibility, best-practices and SEO categories in PageSpeed API requests
- Adjust tests to expect category parameters in PageSpeed calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978f8bb734832ea2e46a4b45f70b77