### PR TITLE
feat: audit images missing alt text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,14 @@ import { Button } from "@/components/ui/button";
 
 export default function Home() {
   const [url, setUrl] = useState("");
-  const [messages, setMessages] = useState<any[]>([]);
+  type AuditMessage = {
+    message?: string;
+    status?: string;
+    summary?: unknown;
+    imagesWithoutAlt?: number;
+    [key: string]: unknown;
+  };
+  const [messages, setMessages] = useState<AuditMessage[]>([]);
 
   async function start() {
     setMessages([]);
@@ -16,7 +23,7 @@ export default function Home() {
     const { auditId } = await res.json();
     const es = new EventSource(`/api/audit/${auditId}`);
     es.onmessage = (ev) => {
-      const data = JSON.parse(ev.data);
+      const data: AuditMessage = JSON.parse(ev.data);
       setMessages((m) => [...m, data]);
       if (data.status === "done" || data.status === "error") {
         es.close();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Home() {
   const [url, setUrl] = useState("");
-  const [messages, setMessages] = useState<string[]>([]);
+  const [messages, setMessages] = useState<any[]>([]);
 
   async function start() {
     setMessages([]);
@@ -17,7 +17,7 @@ export default function Home() {
     const es = new EventSource(`/api/audit/${auditId}`);
     es.onmessage = (ev) => {
       const data = JSON.parse(ev.data);
-      setMessages((m) => [...m, JSON.stringify(data)]);
+      setMessages((m) => [...m, data]);
       if (data.status === "done" || data.status === "error") {
         es.close();
       }
@@ -38,7 +38,10 @@ export default function Home() {
       <div className="flex flex-col space-y-2">
         {messages.map((m, i) => (
           <div key={i} className="p-2 rounded border ">
-            {m}
+            <pre>{JSON.stringify(m)}</pre>
+            {m.imagesWithoutAlt !== undefined && (
+              <div>Images without alt: {m.imagesWithoutAlt}</div>
+            )}
           </div>
         ))}
       </div>

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -29,7 +29,7 @@ describe("audit images without alt", () => {
     nock("https://example.com").get("/").reply(200, html);
     const id = await startAudit("https://example.com");
     const emitter = getEmitter(id)!;
-    const data: any = await new Promise((resolve) => {
+    const data = await new Promise<{ imagesWithoutAlt: number }>((resolve) => {
       emitter.on("done", resolve);
     });
     expect(data.imagesWithoutAlt).toBe(2);
@@ -40,7 +40,7 @@ describe("audit images without alt", () => {
     nock("https://example.org").get("/").reply(200, html);
     const id = await startAudit("https://example.org");
     const emitter = getEmitter(id)!;
-    const data: any = await new Promise((resolve) => {
+    const data = await new Promise<{ imagesWithoutAlt: number }>((resolve) => {
       emitter.on("done", resolve);
     });
     expect(data.imagesWithoutAlt).toBe(0);

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import nock from "nock";
+import { startAudit, getEmitter } from "./audit";
+
+vi.mock("@/lib/prisma", () => {
+  let id = 0;
+  return {
+    prisma: {
+      audit: {
+        create: vi.fn().mockImplementation(() => Promise.resolve({ id: `${++id}` })),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/tools", () => ({
+  fetchWordPressInfo: vi.fn().mockResolvedValue({}),
+  fetchPageSpeedScores: vi.fn().mockResolvedValue({}),
+}));
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("audit images without alt", () => {
+  it("counts images missing alt", async () => {
+    const html = `<!doctype html><img src="a.jpg"><img src="b.jpg" alt=""><img src="c.jpg" alt="c">`;
+    nock("https://example.com").get("/").reply(200, html);
+    const id = await startAudit("https://example.com");
+    const emitter = getEmitter(id)!;
+    const data: any = await new Promise((resolve) => {
+      emitter.on("done", resolve);
+    });
+    expect(data.imagesWithoutAlt).toBe(2);
+  });
+
+  it("returns zero when all images have alt", async () => {
+    const html = `<!doctype html><img src="a.jpg" alt="a"><img src="b.jpg" alt="b">`;
+    nock("https://example.org").get("/").reply(200, html);
+    const id = await startAudit("https://example.org");
+    const emitter = getEmitter(id)!;
+    const data: any = await new Promise((resolve) => {
+      emitter.on("done", resolve);
+    });
+    expect(data.imagesWithoutAlt).toBe(0);
+  });
+});

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -29,6 +29,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
     const title = $("title").first().text().trim();
     const metaDesc = $('meta[name="description"]').attr("content");
     const h1Count = $("h1").length;
+    const imagesWithoutAlt = $('img:not([alt]), img[alt=""]').length;
     emitter.emit("progress", { message: "Checking WordPress info..." });
     const wpInfo = await fetchWordPressInfo(url);
     emitter.emit("progress", { message: "Fetching PageSpeed Insights..." });
@@ -38,6 +39,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       title,
       metaDescPresent: Boolean(metaDesc),
       h1Count,
+      imagesWithoutAlt,
       ...wpInfo,
       ...psi,
     };


### PR DESCRIPTION
## Summary
- track number of images without alt text during audits
- surface `imagesWithoutAlt` metric in audit UI
- test `imagesWithoutAlt` counts for pages with and without alt attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897aa21ee24832e830fbaa65389b684