### PR TITLE
Remove images without alt label

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,9 +46,6 @@ export default function Home() {
         {messages.map((m, i) => (
           <div key={i} className="p-2 rounded border ">
             <pre>{JSON.stringify(m)}</pre>
-            {m.imagesWithoutAlt !== undefined && (
-              <div>Images without alt: {m.imagesWithoutAlt}</div>
-            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- stop showing a separate "Images without alt" line in audit output for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897af543c30832e9424eaa91915b1d3