### PR TITLE
feat: add vulnerability lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 DATABASE_URL="file:./dev.db"
 # Optional PageSpeed Insights API key
 PAGESPEED_API_KEY=""
+# Optional WPScan/WPVulnDB API token
+WPSCAN_API_TOKEN=""
+# Alternative WPVulnDB API token
+WPVULNDB_API_TOKEN=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/react-dom": "19.1.7",
         "eslint": "9.32.0",
         "eslint-config-next": "15.4.6",
-        "nock": "^14.0.9",
+        "nock": "14.0.9",
         "prisma": "6.13.0",
         "tailwindcss": "4.1.11",
         "typescript": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "19.1.7",
     "eslint": "9.32.0",
     "eslint-config-next": "15.4.6",
-    "nock": "^14.0.9",
+    "nock": "14.0.9",
     "prisma": "6.13.0",
     "tailwindcss": "4.1.11",
     "typescript": "5.9.2",

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/lib/tools", async () => {
     ...actual,
     fetchWordPressInfo: vi.fn().mockResolvedValue({ isWordPress: false }),
     fetchPageSpeedScores: vi.fn().mockResolvedValue({}),
+    fetchVulnerabilities: vi.fn().mockResolvedValue({}),
   };
 });
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import {
   fetchPageSpeedScores,
   fetchWordPressInfo,
+  fetchVulnerabilities,
   robotsTxtExists,
   sitemapExists,
 } from "@/lib/tools";
@@ -46,11 +47,54 @@ async function process(id: string, url: string, emitter: EventEmitter) {
     const missingSecurityHeaders = requiredSecurityHeaders.filter(
       (h) => !res.headers[h as keyof typeof res.headers]
     );
+
+    const pluginSlugs = new Set<string>();
+    const themeSlugs = new Set<string>();
+    for (const match of res.body.matchAll(/wp-content\/plugins\/([a-z0-9-]+)/gi)) {
+      pluginSlugs.add(match[1]);
+    }
+    for (const match of res.body.matchAll(/wp-content\/themes\/([a-z0-9-]+)/gi)) {
+      themeSlugs.add(match[1]);
+    }
+    try {
+      const pluginsApi = await got(new URL("/wp-json/wp/v2/plugins", url).toString(), {
+        timeout: { request: 8000 },
+        retry: { limit: 1 },
+        headers: { "user-agent": "WP-Audit-Chat" },
+      }).json<any[]>();
+      for (const p of pluginsApi) {
+        const slug = p?.slug || p?.id || p?.name;
+        if (typeof slug === "string") pluginSlugs.add(slug);
+      }
+    } catch {
+      // ignore
+    }
+    try {
+      const themesApi = await got(new URL("/wp-json/wp/v2/themes", url).toString(), {
+        timeout: { request: 8000 },
+        retry: { limit: 1 },
+        headers: { "user-agent": "WP-Audit-Chat" },
+      }).json<any[]>();
+      for (const t of themesApi) {
+        const slug = t?.slug || t?.id || t?.name;
+        if (typeof slug === "string") themeSlugs.add(slug);
+      }
+    } catch {
+      // ignore
+    }
     emitter.emit("progress", { message: "Checking WordPress info..." });
-    const [wpInfo, robotsTxtPresent, sitemapPresent] = await Promise.all([
+    const [
+      wpInfo,
+      robotsTxtPresent,
+      sitemapPresent,
+      pluginVulns,
+      themeVulns,
+    ] = await Promise.all([
       fetchWordPressInfo(url),
       robotsTxtExists(url),
       sitemapExists(url),
+      fetchVulnerabilities("plugin", pluginSlugs),
+      fetchVulnerabilities("theme", themeSlugs),
     ]);
     emitter.emit("progress", { message: "Fetching PageSpeed Insights..." });
     const psi = await fetchPageSpeedScores(url);
@@ -68,6 +112,9 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       name: wpInfo.name,
       wpVersion: wpInfo.wpVersion,
       isUpToDate: wpInfo.isUpToDate,
+       plugins: Array.from(pluginSlugs),
+       themes: Array.from(themeSlugs),
+       vulnerabilities: { plugins: pluginVulns, themes: themeVulns },
       ...psi,
     };
     await prisma.audit.update({

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -12,6 +12,12 @@ import {
 
 const emitters = new Map<string, EventEmitter>();
 
+interface WpEntity {
+  slug?: string;
+  id?: string | number;
+  name?: string;
+}
+
 export async function startAudit(url: string): Promise<string> {
   const audit = await prisma.audit.create({
     data: { url, status: "queued" },
@@ -61,7 +67,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
         timeout: { request: 8000 },
         retry: { limit: 1 },
         headers: { "user-agent": "WP-Audit-Chat" },
-      }).json<any[]>();
+      }).json<WpEntity[]>();
       for (const p of pluginsApi) {
         const slug = p?.slug || p?.id || p?.name;
         if (typeof slug === "string") pluginSlugs.add(slug);
@@ -74,7 +80,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
         timeout: { request: 8000 },
         retry: { limit: 1 },
         headers: { "user-agent": "WP-Audit-Chat" },
-      }).json<any[]>();
+      }).json<WpEntity[]>();
       for (const t of themesApi) {
         const slug = t?.slug || t?.id || t?.name;
         if (typeof slug === "string") themeSlugs.add(slug);

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -148,6 +148,16 @@ export interface Vulnerability {
   references: string[];
 }
 
+interface WpScanApiVulnerability {
+  references?: Record<string, unknown>;
+  cvss?: { score?: number };
+  fixed_in?: string;
+}
+
+interface WpScanApiResponse {
+  vulnerabilities?: WpScanApiVulnerability[];
+}
+
 function scoreToSeverity(score: number): string {
   if (score >= 9) return "critical";
   if (score >= 7) return "high";
@@ -176,7 +186,7 @@ export async function fetchVulnerabilities(
           timeout: { request: 8000 },
           retry: { limit: 1 },
         }
-      ).json<{ vulnerabilities?: any[] }>();
+      ).json<WpScanApiResponse>();
 
       const vulns = res.vulnerabilities ?? [];
       results[slug] = vulns.map((v) => {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -141,3 +141,66 @@ export async function sitemapExists(siteUrl: string): Promise<boolean> {
     return false;
   }
 }
+
+export interface Vulnerability {
+  severity: string | null;
+  fixedIn?: string;
+  references: string[];
+}
+
+function scoreToSeverity(score: number): string {
+  if (score >= 9) return "critical";
+  if (score >= 7) return "high";
+  if (score >= 4) return "medium";
+  return "low";
+}
+
+export async function fetchVulnerabilities(
+  type: "plugin" | "theme",
+  slugs: Iterable<string>
+): Promise<Record<string, Vulnerability[]>> {
+  const token =
+    process.env.WPSCAN_API_TOKEN || process.env.WPVULNDB_API_TOKEN;
+  if (!token) return {};
+
+  const results: Record<string, Vulnerability[]> = {};
+  for (const slug of slugs) {
+    try {
+      const res = await got(
+        `https://wpscan.com/api/v3/${type}s/${slug}`,
+        {
+          headers: {
+            Authorization: `Token token=${token}`,
+            "user-agent": "WP-Audit-Chat",
+          },
+          timeout: { request: 8000 },
+          retry: { limit: 1 },
+        }
+      ).json<{ vulnerabilities?: any[] }>();
+
+      const vulns = res.vulnerabilities ?? [];
+      results[slug] = vulns.map((v) => {
+        const refs: string[] = [];
+        const refObj = v.references ?? {};
+        for (const val of Object.values(refObj)) {
+          if (Array.isArray(val)) {
+            refs.push(...val.map(String));
+          }
+        }
+        let severity: string | null = null;
+        const score = Number(v.cvss?.score);
+        if (!Number.isNaN(score)) {
+          severity = scoreToSeverity(score);
+        }
+        return {
+          severity,
+          fixedIn: v.fixed_in,
+          references: refs,
+        } satisfies Vulnerability;
+      });
+    } catch {
+      // ignore errors per slug
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- add `fetchVulnerabilities` helper for WPScan/WPVulnDB API queries
- detect plugins and themes during audits and append vulnerability info
- document optional API tokens and tidy tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bc73d504832e9e740faa549c5815