### PR TITLE
Track additional security headers and flag misconfigurations

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,8 @@ export default function Home() {
     status?: string;
     summary?: unknown;
     imagesWithoutAlt?: number;
+    missingSecurityHeaders?: string[];
+    misconfiguredSecurityHeaders?: string[];
     [key: string]: unknown;
   };
   const [messages, setMessages] = useState<AuditMessage[]>([]);
@@ -45,6 +47,27 @@ export default function Home() {
       <div className="flex flex-col space-y-2">
         {messages.map((m, i) => (
           <div key={i} className="p-2 rounded border ">
+            {m.missingSecurityHeaders && m.missingSecurityHeaders.length > 0 && (
+              <div className="mb-2">
+                <strong>Missing security headers:</strong>
+                <ul className="list-disc ml-5">
+                  {m.missingSecurityHeaders.map((h) => (
+                    <li key={h}>{h}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {m.misconfiguredSecurityHeaders &&
+              m.misconfiguredSecurityHeaders.length > 0 && (
+                <div className="mb-2">
+                  <strong>Misconfigured security headers:</strong>
+                  <ul className="list-disc ml-5">
+                    {m.misconfiguredSecurityHeaders.map((h) => (
+                      <li key={h}>{h}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             <pre>{JSON.stringify(m)}</pre>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Monitor additional headers (`permissions-policy`, `cross-origin-opener-policy`, `cross-origin-embedder-policy`) and validate recommended values
- Surface misconfigured headers in audit results and UI
- Add tests for missing and misconfigured security headers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68983ccb1960832e9da29181bb67b15a