### PR TITLE
feat: detect broken links

### DIFF
--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,74 @@
+import got from "got";
+import * as cheerio from "cheerio";
+
+export interface BrokenLinksResult {
+  total: number;
+  broken: string[];
+}
+
+/**
+ * Extract anchor tags from HTML and check for broken links.
+ * Performs HEAD requests (falling back to GET when necessary) with a
+ * concurrency limit. URLs returning 4xx/5xx are reported as broken.
+ */
+export async function checkBrokenLinks(
+  baseUrl: string,
+  html: string,
+  concurrency = 5
+): Promise<BrokenLinksResult> {
+  const $ = cheerio.load(html);
+  const hrefs = new Set<string>();
+  $("a[href]").each((_, el) => {
+    const href = $(el).attr("href");
+    if (!href) return;
+    try {
+      const u = new URL(href, baseUrl);
+      if (u.protocol === "http:" || u.protocol === "https:") {
+        hrefs.add(u.toString());
+      }
+    } catch {
+      // ignore invalid URLs
+    }
+  });
+
+  const urls = Array.from(hrefs);
+  const broken: string[] = [];
+  let index = 0;
+
+  async function worker() {
+    while (index < urls.length) {
+      const current = urls[index++];
+      try {
+        let res = await got(current, {
+          method: "HEAD",
+          throwHttpErrors: false,
+          retry: { limit: 1 },
+          timeout: { request: 8000 },
+        });
+        if (res.statusCode >= 400) {
+          if (res.statusCode === 405 || res.statusCode === 501) {
+            res = await got(current, {
+              method: "GET",
+              throwHttpErrors: false,
+              retry: { limit: 1 },
+              timeout: { request: 8000 },
+            });
+          }
+          if (res.statusCode >= 400) {
+            broken.push(current);
+          }
+        }
+      } catch {
+        broken.push(current);
+      }
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, urls.length) },
+    () => worker()
+  );
+  await Promise.all(workers);
+
+  return { total: urls.length, broken };
+}


### PR DESCRIPTION
## Summary
- scan page anchors and report HTTP 4xx/5xx links with concurrency control
- surface broken link count and URLs in audit summaries
- test audit workflow for broken link detection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68983f724da0832e846df9bfeb92283d