### PR TITLE
Detect WordPress caching layers

### DIFF
--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/lib/tools", async () => {
   const actual = await vi.importActual<typeof import("./tools")>("./tools");
   return {
     ...actual,
-    fetchWordPressInfo: vi.fn().mockResolvedValue({ isWordPress: false }),
+    fetchWordPressInfo: vi.fn().mockResolvedValue({ isWordPress: false, caching: [] }),
     fetchPageSpeedScores: vi.fn().mockResolvedValue({}),
     fetchVulnerabilities: vi.fn().mockResolvedValue({}),
   };

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -158,6 +158,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       name: wpInfo.name,
       wpVersion: wpInfo.wpVersion,
       isUpToDate: wpInfo.isUpToDate,
+      caching: wpInfo.caching,
       plugins: Array.from(pluginSlugs),
       themes: Array.from(themeSlugs),
       vulnerabilities: { plugins: pluginVulns, themes: themeVulns },

--- a/src/lib/tools.test.ts
+++ b/src/lib/tools.test.ts
@@ -29,7 +29,11 @@ describe("fetchWordPressInfo", () => {
       .get("/wp-json")
       .reply(200, { name: "Example" })
       .get("/")
-      .reply(200, "<meta name=\"generator\" content=\"WordPress 6.5.2\">");
+      .reply(
+        200,
+        "<meta name=\"generator\" content=\"WordPress 6.5.2\">",
+        { "x-cache-enabled": "true" }
+      );
     nock("https://api.wordpress.org")
       .get("/core/stable-check/1.0/")
       .query({ version: "6.5.2" })
@@ -40,6 +44,7 @@ describe("fetchWordPressInfo", () => {
       name: "Example",
       wpVersion: "6.5.2",
       isUpToDate: true,
+      caching: ["WP Rocket"],
     });
   });
 
@@ -52,6 +57,7 @@ describe("fetchWordPressInfo", () => {
     const info = await fetchWordPressInfo("https://notwp.com");
     expect(info.isWordPress).toBe(false);
     expect(info.wpVersion).toBeUndefined();
+    expect(info.caching).toEqual([]);
   });
 
   it("flags outdated WordPress versions", async () => {
@@ -67,6 +73,7 @@ describe("fetchWordPressInfo", () => {
     const info = await fetchWordPressInfo("https://oldwp.com");
     expect(info.isWordPress).toBe(true);
     expect(info.isUpToDate).toBe(false);
+    expect(info.caching).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- track common caching indicators in WordPress responses
- expose detected caching layers in audit summary
- add unit tests for caching detection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689863317458832e9a6253b1e818ef69