### PR TITLE
Add XML-RPC and user enumeration security checks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,8 @@ export default function Home() {
     imagesWithoutAlt?: number;
     missingSecurityHeaders?: string[];
     misconfiguredSecurityHeaders?: string[];
+    xmlRpcEnabled?: boolean;
+    userEnumerationEnabled?: boolean;
     [key: string]: unknown;
   };
   const [messages, setMessages] = useState<AuditMessage[]>([]);

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -21,6 +21,8 @@ vi.mock("@/lib/tools", async () => {
     fetchWordPressInfo: vi.fn().mockResolvedValue({ isWordPress: false, caching: [] }),
     fetchPageSpeedScores: vi.fn().mockResolvedValue({}),
     fetchVulnerabilities: vi.fn().mockResolvedValue({}),
+    checkXmlRpc: vi.fn().mockResolvedValue(false),
+    checkUserEnumeration: vi.fn().mockResolvedValue(false),
   };
 });
 
@@ -99,6 +101,8 @@ describe("additional checks", () => {
       sitemapPresent: boolean;
       missingSecurityHeaders: string[];
       usesHttps: boolean;
+      xmlRpcEnabled: boolean;
+      userEnumerationEnabled: boolean;
     }>((resolve) => {
       emitter.on("done", resolve);
     });
@@ -107,6 +111,8 @@ describe("additional checks", () => {
     expect(data.missingSecurityHeaders).toContain("content-security-policy");
     expect(data.missingSecurityHeaders).toContain("permissions-policy");
     expect(data.usesHttps).toBe(true);
+    expect(data.xmlRpcEnabled).toBe(false);
+    expect(data.userEnumerationEnabled).toBe(false);
   });
 
   it("flags misconfigured security headers", async () => {

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -8,6 +8,8 @@ import {
   fetchPageSpeedScores,
   fetchWordPressInfo,
   fetchVulnerabilities,
+  checkXmlRpc,
+  checkUserEnumeration,
   robotsTxtExists,
   sitemapExists,
 } from "@/lib/tools";
@@ -129,12 +131,16 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       sitemapPresent,
       pluginVulns,
       themeVulns,
+      xmlRpcEnabled,
+      userEnumerationEnabled,
     ] = await Promise.all([
       fetchWordPressInfo(url),
       robotsTxtExists(url),
       sitemapExists(url),
       fetchVulnerabilities("plugin", pluginSlugs),
       fetchVulnerabilities("theme", themeSlugs),
+      checkXmlRpc(url),
+      checkUserEnumeration(url),
     ]);
     emitter.emit("progress", { message: "Fetching PageSpeed Insights..." });
     const psi = await fetchPageSpeedScores(url);
@@ -154,6 +160,8 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       accessibilityViolations,
       missingSecurityHeaders,
       misconfiguredSecurityHeaders,
+      xmlRpcEnabled,
+      userEnumerationEnabled,
       isWordPress: wpInfo.isWordPress,
       name: wpInfo.name,
       wpVersion: wpInfo.wpVersion,


### PR DESCRIPTION
## Summary
- add `checkXmlRpc` and `checkUserEnumeration` helpers for probing WordPress XML-RPC and REST endpoints
- surface XML-RPC and user enumeration flags in audit summaries
- cover new helpers with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689865a54344832e9ba5fb9332ecc0e9