### PR TITLE
Add Safe Browsing malware check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 DATABASE_URL="file:./dev.db"
 # Optional PageSpeed Insights API key
 PAGESPEED_API_KEY=""
+# Optional Google Safe Browsing API key
+SAFE_BROWSING_API_KEY=""
 # Optional WPScan/WPVulnDB API token
 WPSCAN_API_TOKEN=""
 # Alternative WPVulnDB API token

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Uses [Prisma](https://www.prisma.io/) with a SQLite database file.
    npm install
    cp .env.example .env # sets DATABASE_URL for SQLite
    # add your PageSpeed Insights API key to .env as PAGESPEED_API_KEY
+   # add your Safe Browsing API key to .env as SAFE_BROWSING_API_KEY
    npx prisma db push # create the dev.db SQLite file
    npm run dev
    ```

--- a/src/lib/audit.test.ts
+++ b/src/lib/audit.test.ts
@@ -34,6 +34,7 @@ vi.mock("@/lib/tools", async () => {
     checkDirectoryListing: vi.fn().mockResolvedValue(false),
     checkWpConfigBackup: vi.fn().mockResolvedValue(false),
     fetchStructuredData: vi.fn().mockResolvedValue({ items: [] }),
+    checkSafeBrowsing: vi.fn().mockResolvedValue([]),
   };
 });
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -16,6 +16,7 @@ import {
   checkWpConfigBackup,
   fetchLatestVersion,
   fetchStructuredData,
+  checkSafeBrowsing,
 } from "@/lib/tools";
 import { fetchSslInfo, fetchSslLabs } from "@/lib/ssl";
 import { checkBrokenLinks, checkBrokenImages } from "./links";
@@ -237,6 +238,8 @@ async function process(id: string, url: string, emitter: EventEmitter) {
     const { broken: brokenLinks } = await checkBrokenLinks(url, res.body);
     emitter.emit("progress", { message: "Checking for broken images..." });
     const { broken: brokenImages } = await checkBrokenImages(url, res.body);
+    emitter.emit("progress", { message: "Checking Google Safe Browsing..." });
+    const safeBrowsingThreats = await checkSafeBrowsing(url);
     emitter.emit("progress", { message: "Checking WordPress info..." });
     const [
       wpInfo,
@@ -333,6 +336,7 @@ async function process(id: string, url: string, emitter: EventEmitter) {
       themes: themeDetails,
       vulnerabilities: { plugins: pluginVulns, themes: themeVulns },
       structuredData: structuredData?.items ?? [],
+      safeBrowsingThreats,
       ...psi,
     };
     await prisma.audit.update({


### PR DESCRIPTION
## Summary
- integrate Google Safe Browsing API to flag malicious or phishing URLs
- document SAFE_BROWSING_API_KEY env var and setup instructions
- cover Safe Browsing logic with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689876d58ef4832ebeeb236576965c04