### PR TITLE
Add missing Google API key env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 DATABASE_URL="file:./dev.db"
 # Optional PageSpeed Insights API key
 PAGESPEED_API_KEY=""
+# Optional Google API key for Rich Results API
+GOOGLE_API_KEY=""
 # Optional Google Safe Browsing API key
 SAFE_BROWSING_API_KEY=""
 # Optional WPScan/WPVulnDB API token


### PR DESCRIPTION
## Summary
- add GOOGLE_API_KEY to .env.example

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898790eb3ec832e951c5dbf51eda92c