### PR TITLE
Add tests for link checker and audit request validator

### DIFF
--- a/src/lib/links.test.ts
+++ b/src/lib/links.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import nock from "nock";
+import { checkBrokenLinks, checkBrokenImages } from "./links";
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("checkBrokenLinks", () => {
+  it("identifies broken links", async () => {
+    const html = `
+      <a href="/ok">ok</a>
+      <a href="/missing">missing</a>
+      <a href="/method">method</a>
+      <a href="https://external.com/ok">external</a>
+      <a href="/duplicate">dup1</a>
+      <a href="/duplicate">dup2</a>
+    `;
+    nock("https://site.com")
+      .head("/ok").reply(200)
+      .head("/missing").reply(404)
+      .head("/method").reply(405)
+      .get("/method").reply(200)
+      .head("/duplicate").reply(200);
+    nock("https://external.com")
+      .head("/ok").reply(200);
+
+    const result = await checkBrokenLinks("https://site.com", html);
+    expect(result.total).toBe(5);
+    expect(result.broken).toEqual(["https://site.com/missing"]);
+  });
+});
+
+describe("checkBrokenImages", () => {
+  it("identifies broken images", async () => {
+    const html = `
+      <img src="/ok" />
+      <img src="/missing" />
+      <img src="/method" />
+      <img src="https://cdn.com/good.jpg" />
+      <img src="/dup" />
+      <img src="/dup" />
+    `;
+    nock("https://images.com")
+      .head("/ok").reply(200)
+      .head("/missing").reply(404)
+      .head("/method").reply(405)
+      .get("/method").reply(200)
+      .head("/dup").reply(200);
+    nock("https://cdn.com")
+      .head("/good.jpg").reply(200);
+
+    const result = await checkBrokenImages("https://images.com", html);
+    expect(result.total).toBe(5);
+    expect(result.broken).toEqual(["https://images.com/missing"]);
+  });
+});

--- a/src/lib/validators.test.ts
+++ b/src/lib/validators.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { auditRequestSchema } from "./validators";
+
+describe("auditRequestSchema", () => {
+  it("accepts valid URLs", () => {
+    const result = auditRequestSchema.safeParse({ url: "https://example.com" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid URLs", () => {
+    const result = auditRequestSchema.safeParse({ url: "not-a-url" });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- test link utilities for detection of broken links and images
- test audit request validator for valid and invalid URLs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68987fdd691c832ebf3ef4f5c252caad